### PR TITLE
fix: cmake warnings

### DIFF
--- a/include/string-searching/rabin_karp_substring_searcher.hpp
+++ b/include/string-searching/rabin_karp_substring_searcher.hpp
@@ -11,6 +11,11 @@
 class RabinKarpSearcher : public BaseSubstringSearcher {
 public:
     /**
+     * @brief Constructs a Rabin-Karp searcher with default params.
+     */
+    RabinKarpSearcher();
+
+    /**
      * @brief Constructs a Rabin-Karp searcher with given alphabet size and prime number.
      */
     RabinKarpSearcher(size_t alphabet_size, size_t prime);
@@ -27,8 +32,8 @@ private:
     size_t ComputeHash(const std::string& str, size_t length) const;
     size_t RollHash(size_t old_hash, char old_char, char new_char, size_t highest_power) const;
 
-    size_t alphabet_size_;
-    size_t prime_;
+    size_t alphabet_size_ = 256;
+    size_t prime_ = 1e9 + 7;
 };
 
 #endif  // RABIN_KARP_SEARCHER_HPP_

--- a/simulator/src/algorithms_creator.cpp
+++ b/simulator/src/algorithms_creator.cpp
@@ -1,6 +1,8 @@
 #include <simulator/algorithms_creator.hpp>
 #include <stdexcept>
+#include <string-searching/kmp_substring_searcher.hpp>
 #include <string-searching/naive_substring_searcher.hpp>
+#include <string-searching/rabin_karp_substring_searcher.hpp>
 #include <string-searching/z_substring_searcher.hpp>
 
 AlgorithmList AlgorithmsCreator::CreateAlgorithms(
@@ -17,8 +19,14 @@ AlgorithmList AlgorithmsCreator::CreateAlgorithms(
                     break;
                 case SubstringSearchAlgorithm::kZFunction:
                     algorithm_list.push_back(std::make_unique<ZSubstringSearcher>());
+                    break;
+                case SubstringSearchAlgorithm::kKmp:
+                    algorithm_list.push_back(std::make_unique<KmpSubstringSearcher>());
+                    break;
+                case SubstringSearchAlgorithm::kRabinKarp:
+                    algorithm_list.push_back(std::make_unique<RabinKarpSearcher>());
+                    break;
             }
-
         } else {
             throw std::invalid_argument(name + " is not in list of implemented algorithms");
         }

--- a/simulator/tests/CMakeLists.txt
+++ b/simulator/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ CPMAddPackage(NAME "string-searching" SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
 
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} PRIVATE simulator gtest gtest_main gmock)
+target_link_libraries(${PROJECT_NAME} PRIVATE simulator gtest_main gmock)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 
 # getting GTest

--- a/src/rabin_karp_substring_searcher.cpp
+++ b/src/rabin_karp_substring_searcher.cpp
@@ -1,4 +1,7 @@
-#include "string-searching/rabin_karp_substring_searcher.hpp"
+#include <string-searching/base_substring_searcher.hpp>
+#include <string-searching/rabin_karp_substring_searcher.hpp>
+
+RabinKarpSearcher::RabinKarpSearcher() : BaseSubstringSearcher("Rabin-Karp") {}
 
 RabinKarpSearcher::RabinKarpSearcher(size_t alphabet_size, size_t prime)
     : BaseSubstringSearcher("Rabin-Karp"), alphabet_size_(alphabet_size), prime_(prime) {}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -42,9 +42,7 @@ endif()
 
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(
-  ${PROJECT_NAME} PRIVATE string-searching::string-searching gtest gtest_main gmock
-)
+target_link_libraries(${PROJECT_NAME} PRIVATE string-searching::string-searching gtest_main gmock)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 
 # getting GTest


### PR DESCRIPTION
Remove gtest duplication.
Fix CreateAlgorithms() method with missed switch-cases.
Add default constructor to RabinKarpSearcher.